### PR TITLE
Added package.json for compatibility with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,5 @@
             "android",
             "ios"
         ]
-    },
-    "engines": {
-        "cordovaDependencies": {
-        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/JonSmart/CordovaYoutubeVideoPlayer.git"
+    "url": "git+https://github.com/franlindebl/CordovaYoutubeVideoPlayer.git"
   },
   "keywords": [
     "cordova",
@@ -30,10 +30,10 @@
     "player",
     "fullscreen"
   ],
-  "author": "Jon Smart",
+  "author": "Fran Linde Blazquez",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/JonSmart/CordovaYoutubeVideoPlayer/pulls"
+    "url": "https://github.com/franlindebl/CordovaYoutubeVideoPlayer/pulls"
   },
-  "homepage": "https://github.com/JonSmart/CordovaYoutubeVideoPlayer#readme"
+  "homepage": "https://github.com/franlindebl/CordovaYoutubeVideoPlayer#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,19 +1,15 @@
 {
-  "name": "cordova-plugin-youtube-video-player",
-  "version": "1.0.6",
-  "description": "Play Youtube Videos in a native Video Player on Android and iOS.",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/franlindebl/CordovaYoutubeVideoPlayer.git"
-  },
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/franlindebl/CordovaYoutubeVideoPlayer/issues"
-  },
-  "homepage": "https://github.com/franlindebl/CordovaYoutubeVideoPlayer#readme"
+	"name": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
+	"version": "1.1",
+	"cordova": {
+		"id": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
+		"platforms": [
+			"android",
+			"ios"
+		]
+	},
+	"engines": {
+		"cordovaDependencies": {
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
-	"version": "1.1",
+	"version": "1.0.1",
 	"cordova": {
 		"id": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
 		"platforms": [

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-	"name": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
-	"version": "1.1",
-	"cordova": {
-		"id": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
-		"platforms": [
-			"android",
-			"ios"
-		]
-	},
-	"engines": {
-		"cordovaDependencies": {
-		}
-	}
+    "name": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
+    "version": "1.1",
+    "cordova": {
+        "id": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
+        "platforms": [
+            "android",
+            "ios"
+        ]
+    },
+    "engines": {
+        "cordovaDependencies": {
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "youtube-video-player",
+  "version": "1.0.0",
+  "description": "Play Youtube Videos in a native Video Player on Android & iOS.",
+  "cordova": {
+    "id": "youtube-video-player",
+    "platforms": [
+      "android",
+      "ios"
+    ]
+  },
+  "engines": {
+    "cordovaDependencies": {
+      "2.0.0": {
+        "cordova": ">100"
+      }
+    }
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JonSmart/CordovaYoutubeVideoPlayer.git"
+  },
+  "keywords": [
+    "cordova",
+    "video",
+    "youtube",
+    "player",
+    "fullscreen"
+  ],
+  "author": "Jon Smart",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/JonSmart/CordovaYoutubeVideoPlayer/pulls"
+  },
+  "homepage": "https://github.com/JonSmart/CordovaYoutubeVideoPlayer#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,21 +1,8 @@
 {
-  "name": "youtube-video-player",
-  "version": "1.0.0",
-  "description": "Play Youtube Videos in a native Video Player on Android & iOS.",
-  "cordova": {
-    "id": "youtube-video-player",
-    "platforms": [
-      "android",
-      "ios"
-    ]
-  },
-  "engines": {
-    "cordovaDependencies": {
-      "2.0.0": {
-        "cordova": ">100"
-      }
-    }
-  },
+  "name": "cordova-plugin-youtube-video-player",
+  "version": "1.0.6",
+  "description": "Play Youtube Videos in a native Video Player on Android and iOS.",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -23,17 +10,10 @@
     "type": "git",
     "url": "git+https://github.com/franlindebl/CordovaYoutubeVideoPlayer.git"
   },
-  "keywords": [
-    "cordova",
-    "video",
-    "youtube",
-    "player",
-    "fullscreen"
-  ],
-  "author": "Fran Linde Blazquez",
-  "license": "MIT",
+  "author": "",
+  "license": "ISC",
   "bugs": {
-    "url": "https://github.com/franlindebl/CordovaYoutubeVideoPlayer/pulls"
+    "url": "https://github.com/franlindebl/CordovaYoutubeVideoPlayer/issues"
   },
   "homepage": "https://github.com/franlindebl/CordovaYoutubeVideoPlayer#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
-    "name": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
-    "version": "1.1",
-    "cordova": {
-        "id": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
-        "platforms": [
-            "android",
-            "ios"
-        ]
-    }
+	"name": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
+	"version": "1.1",
+	"cordova": {
+		"id": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
+		"platforms": [
+			"android",
+			"ios"
+		]
+	},
+	"engines": {
+		"cordovaDependencies": {
+		}
+	}
 }


### PR DESCRIPTION
At the current cordova version (7.0.1) plugins are installed using npm, and npm needs a package.json in order to install a dependency.

For this reason I have created a simple package.json

ERROR installing plugin without package.json:

**cordova plugin add https://github.com/JonSmart/CordovaYoutubeVideoPlayer --save**

**Running command - failed!**

[ERROR] Cordova encountered an error.
You may get more insight by running the Cordova command above directly.

[ERROR] An error occurred while running cordova plugin add https://github.com/JonSmart/CordovaYoutubeVideoPlayer --save (exit code 1):

Error: Failed to fetch plugin https://github.com/JonSmart/CordovaYoutubeVideoPlayer via registry.
Probably this is either a connection problem, or plugin spec is incorrect.
Check your connection and plugin name/version/URL.
Error: npm: Command failed with exit code 235 Error output:
npm ERR! addLocal Could not install /var/folders/6b/cp135pg93clf75nyj69l7dlh0000gn/T/npm-1443-19ba21a7/git-cache-41a343c3/2a0cc8f3790b584ed1aae3927d03f7213e90c9d0
npm ERR! code EISDIR
npm ERR! errno -21
npm ERR! syscall read
npm ERR! eisdir EISDIR: illegal operation on a directory, read
npm ERR! eisdir This is most likely not a problem with npm itself
**npm ERR! eisdir and is related to npm not being able to find a package.json in**
npm ERR! eisdir a package you are trying to install.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/franlinde/.npm/_logs/2017-05-23T08_04_18_747Z-debug.log


