### PR TITLE
Support for cordova-android@7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
 	"name": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
+	"description": "Play Youtube Videos in a native Video Player on Android & iOS.",
 	"version": "1.0.1",
+	"scripts": {
+        	"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"repository": {
+	        "type": "git",
+	        "url": "git+https://github.com/apiaget/CordovaYoutubeVideoPlayer.git"
+    	},
 	"cordova": {
 		"id": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
 		"platforms": [
@@ -11,5 +19,6 @@
 	"engines": {
 		"cordovaDependencies": {
 		}
-	}
+	},
+	"keywords": []
 }

--- a/package.json
+++ b/package.json
@@ -1,24 +1,30 @@
 {
-	"name": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
-	"description": "Play Youtube Videos in a native Video Player on Android & iOS.",
-	"version": "1.0.1",
-	"scripts": {
-        	"test": "echo \"Error: no test specified\" && exit 1"
-	},
-	"repository": {
-	        "type": "git",
-	        "url": "git+https://github.com/apiaget/CordovaYoutubeVideoPlayer.git"
-    	},
-	"cordova": {
-		"id": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
-		"platforms": [
-			"android",
-			"ios"
-		]
-	},
-	"engines": {
-		"cordovaDependencies": {
-		}
-	},
-	"keywords": []
+  "name": "com.bunkerpalace.cordova.youtubevideoplayer",
+  "description": "Play Youtube Videos in a native Video Player on Android & iOS.",
+  "version": "1.0.1",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/apiaget/CordovaYoutubeVideoPlayer.git"
+  },
+  "cordova": {
+    "id": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
+    "platforms": [
+      "android",
+      "ios"
+    ]
+  },
+  "engines": {
+    "cordovaDependencies": {}
+  },
+  "keywords": [],
+  "bugs": {
+    "url": "https://github.com/apiaget/CordovaYoutubeVideoPlayer/issues"
+  },
+  "homepage": "https://github.com/apiaget/CordovaYoutubeVideoPlayer#readme",
+  "main": "index.js",
+  "author": "",
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/apiaget/CordovaYoutubeVideoPlayer.git"
+    "url": "git+https://github.com/JonSmart/CordovaYoutubeVideoPlayer.git"
   },
   "cordova": {
     "id": "com.bunkerpalace.cordova.YoutubeVideoPlayer",
@@ -21,9 +21,9 @@
   },
   "keywords": [],
   "bugs": {
-    "url": "https://github.com/apiaget/CordovaYoutubeVideoPlayer/issues"
+    "url": "https://github.com/JonSmart/CordovaYoutubeVideoPlayer/issues"
   },
-  "homepage": "https://github.com/apiaget/CordovaYoutubeVideoPlayer#readme",
+  "homepage": "https://github.com/JonSmart/CordovaYoutubeVideoPlayer#readme",
   "main": "index.js",
   "author": "",
   "license": "MIT"

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,84 +1,84 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="com.bunkerpalace.cordova.YoutubeVideoPlayer" version="1.0.5">
-
+    
     <name>CordovaYoutubeVideoPlayer</name>
-
+    
     <description>Play Youtube Videos in a native Video Player on Android &amp; iOS.</description>
-
+    
     <author>Adrien Glitchbone - Bunker Palace SA</author>
 
     <keywords>video,youtube,videoplayer</keywords>
-
+    
     <engines>
         <engine name="cordova" version=">=3.0.0" />
-        </engines>
+    </engines>
+    
+    <js-module src="plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/www/YoutubeVideoPlayer.js" name="YoutubeVideoPlayer">
+        <clobbers target="YoutubeVideoPlayer"/>
+    </js-module>
 
-        <js-module src="plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/www/YoutubeVideoPlayer.js" name="YoutubeVideoPlayer">
-            <clobbers target="YoutubeVideoPlayer"/>
-        </js-module>
+    <platform name="android">
+    
+        <config-file target="res/xml/config.xml" parent="widget">
+            <feature name="YoutubeVideoPlayer">
+                <param name="android-package" value="com.bunkerpalace.cordova.YoutubeVideoPlayer"/>
+            </feature>
+        </config-file>
 
-        <platform name="android">
+        <config-file target="AndroidManifest.xml" parent="/manifest">
+            <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+        </config-file>
 
-            <config-file target="res/xml/config.xml" parent="widget">
-                <feature name="YoutubeVideoPlayer">
-                    <param name="android-package" value="com.bunkerpalace.cordova.YoutubeVideoPlayer"/>
-                </feature>
-            </config-file>
+        <config-file target="AndroidManifest.xml" parent="/manifest/application">
+            <activity android:name="com.keyes.youtube.OpenYouTubePlayerActivity" android:screenOrientation="landscape"/>
+            <activity
+                android:name="com.bunkerpalace.cordova.YouTubeActivity"
+                android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale"
+                android:label="@string/activity_name"
+                android:launchMode="singleTop"
+                android:theme="@android:style/Theme.Black.NoTitleBar"
+                android:windowSoftInputMode="adjustResize"/>
+        </config-file>
 
-            <config-file target="AndroidManifest.xml" parent="/manifest">
-                <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
-            </config-file>
+        <source-file src="platforms/android/src/com/bunkerpalace/cordova/YouTubeActivity.java" target-dir="src/com/bunkerpalace/cordova"/>
+        <source-file src="platforms/android/src/com/bunkerpalace/cordova/YoutubeVideoPlayer.java" target-dir="src/com/bunkerpalace/cordova"/>
+        <lib-file src="platforms/android/libs/openyoutubeactivity.jar" />
+        <lib-file src="platforms/android/libs/YouTubeAndroidPlayerApi.jar" />
 
-            <config-file target="AndroidManifest.xml" parent="/manifest/application">
-                <activity android:name="com.keyes.youtube.OpenYouTubePlayerActivity" android:screenOrientation="landscape"/>
-                <activity
-                    android:name="com.bunkerpalace.cordova.YouTubeActivity"
-                    android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale"
-                    android:label="@string/activity_name"
-                    android:launchMode="singleTop"
-                    android:theme="@android:style/Theme.Black.NoTitleBar"
-                    android:windowSoftInputMode="adjustResize"/>
-            </config-file>
+    </platform>
 
-            <source-file src="platforms/android/src/com/bunkerpalace/cordova/YouTubeActivity.java" target-dir="src/com/bunkerpalace/cordova"/>
-            <source-file src="platforms/android/src/com/bunkerpalace/cordova/YoutubeVideoPlayer.java" target-dir="src/com/bunkerpalace/cordova"/>
-            <source-file src="platforms/android/libs/openyoutubeactivity.jar" target-dir="libs"/>
-            <source-file src="platforms/android/libs/YouTubeAndroidPlayerApi.jar" target-dir="libs"/>
+    <platform name="ios">
 
-        </platform>
+        <config-file target="config.xml" parent="/*">
+            <feature name="YoutubeVideoPlayer">
+                <param name="ios-package" value="YoutubeVideoPlayer"/>
+            </feature>
+        </config-file>
 
-        <platform name="ios">
+        <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeClient.h"/>
+        <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeClient.m"/>
+        <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeError.h"/>
+        <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeKit.h"/>
+        <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeOperation.h"/>
+        <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubePlayerScript.h"/>
+        <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubePlayerScript.m"/>
+        <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideo.h"/>
+        <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideo.m"/>
+        <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideo+Private.h"/>
+        <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideoOperation.h"/>
+        <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideoOperation.m"/>
+        <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideoPlayerViewController.h"/>
+        <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideoPlayerViewController.m"/>
+        <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideoWebpage.h"/>
+        <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideoWebpage.m"/>
+        <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/YoutubeVideoPlayer.h"/>
+        <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/YoutubeVideoPlayer.m"/>
 
-            <config-file target="config.xml" parent="/*">
-                <feature name="YoutubeVideoPlayer">
-                    <param name="ios-package" value="YoutubeVideoPlayer"/>
-                </feature>
-            </config-file>
+        <framework src="MediaPlayer.framework"/>
+        <framework src="AVFoundation.framework"/>
+        <framework src="JavaScriptCore.framework"/>
 
-            <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeClient.h"/>
-            <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeClient.m"/>
-            <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeError.h"/>
-            <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeKit.h"/>
-            <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeOperation.h"/>
-            <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubePlayerScript.h"/>
-            <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubePlayerScript.m"/>
-            <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideo.h"/>
-            <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideo.m"/>
-            <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideo+Private.h"/>
-            <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideoOperation.h"/>
-            <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideoOperation.m"/>
-            <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideoPlayerViewController.h"/>
-            <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideoPlayerViewController.m"/>
-            <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideoWebpage.h"/>
-            <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/XCDYouTubeVideoWebpage.m"/>
-            <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/YoutubeVideoPlayer.h"/>
-            <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/YoutubeVideoPlayer.m"/>
+    </platform>
 
-            <framework src="MediaPlayer.framework"/>
-            <framework src="AVFoundation.framework"/>
-            <framework src="JavaScriptCore.framework"/>
-
-        </platform>
-
-    </plugin>
+</plugin>


### PR DESCRIPTION
Hello !

The breaking change in cordova-android@7.0.0 and newer was a problem for me so I suggest some modification to enable compatibility with cordova-android@7.0.0. (https://cordova.apache.org/announcements/2017/12/04/cordova-android-7.0.0.html).

I tested to build apps with platform cordova-android@6.4.0 and 7.0.0 and retrocompatibilty seems okay (build do not throw error and plugin functionnalities are the same in (6.4.0 and 7.0.0) )

I also suggested some modification to the package.json as it seemed need when I executed the command cordova plugin add ...

Should the version of the plugin be upgraded too ?

Axel